### PR TITLE
Fix collapsed sidebar retaining note space

### DIFF
--- a/src/app/components/main/main.component.html
+++ b/src/app/components/main/main.component.html
@@ -10,8 +10,8 @@
       }
     }
     <div class="d-flex">
-        <div class="sidenav-sticky">
-            <app-sidenav></app-sidenav>
+        <div class="sidenav-sticky" [class.sidebar-collapsed]="sidebarCollapsed">
+            <app-sidenav (collapsedChange)="sidebarCollapsed = $event"></app-sidenav>
         </div>
         <div class="w-100 padding">
             <app-input class="desktop-placeholder-input"></app-input>

--- a/src/app/components/main/main.component.scss
+++ b/src/app/components/main/main.component.scss
@@ -27,6 +27,14 @@
       width: 280px;
       z-index: 900;
     }
+    &.sidebar-collapsed {
+      flex-basis: 80px;
+      width: 80px;
+
+      app-sidenav {
+        width: 80px;
+      }
+    }
   }
 
 

--- a/src/app/components/main/main.component.ts
+++ b/src/app/components/main/main.component.ts
@@ -119,6 +119,7 @@ const KeptModelManager = registerPlugin<KeptModelManagerPlugin>('KeptModelManage
 export class MainComponent implements OnInit, OnDestroy {
 
   readonly nativePhoneLayout = isNativePhonePlatform();
+  sidebarCollapsed = false;
   installHelpOpen = false;
   smartCaptureOpen = false;
   smartCaptureListening = false;

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SharedService } from 'src/app/services/shared.service';
 import { LabelActionsT } from 'src/app/interfaces/labels';
@@ -22,6 +22,7 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild("binderInput") binderInput !: ElementRef<HTMLInputElement>
   @ViewChild("binderError") binderError !: ElementRef<HTMLInputElement>
   @ViewChild('labelsScroll') labelsScroll?: ElementRef<HTMLDivElement>
+  @Output() collapsedChange = new EventEmitter<boolean>();
 
   isMobileOpen = false;
   readonly nativePhoneDrawer = isNativePhonePlatform();
@@ -132,10 +133,10 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
 
   collapseSideBar() {
     const sidebar = document.querySelector('[sideBar]');
-    if (sidebar) {
-      sidebar.classList.toggle('close');
-      this.isMobileOpen = !sidebar.classList.contains('close') && this.usesDrawerSidebar();
-    }
+    if (!sidebar) return;
+
+    sidebar.classList.toggle('close');
+    this.updateSidebarState(sidebar);
   }
 
   closeSideBarIfOpen() {
@@ -143,7 +144,7 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
     const sidebar = document.querySelector('[sideBar]')
     if (sidebar && !sidebar.classList.contains('close')) {
       sidebar.classList.add('close')
-      this.isMobileOpen = false
+      this.updateSidebarState(sidebar)
     }
   }
 
@@ -152,8 +153,14 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
     const sidebar = document.querySelector('[sideBar]')
     if (sidebar && !sidebar.classList.contains('close')) {
       sidebar.classList.add('close')
-      this.isMobileOpen = false;
+      this.updateSidebarState(sidebar)
     }
+  }
+
+  private updateSidebarState(sidebar: Element) {
+    const collapsed = sidebar.classList.contains('close');
+    this.collapsedChange.emit(collapsed);
+    this.isMobileOpen = !collapsed && this.usesDrawerSidebar();
   }
 
   toggleTheme() {
@@ -185,16 +192,15 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
       this.Shared.closeSideBar.subscribe(x => { if (x) this.collapseSideBar() }),
       this.Shared.closeSideBarIfOpen.subscribe(x => { if (x) this.closeSideBarIfOpen() })
     );
-    if (this.usesDrawerSidebar()) {
-      const sidebar = document.querySelector('[sideBar]');
-      if (sidebar && !sidebar.classList.contains('close')) {
-        sidebar.classList.add('close');
-      }
-      this.isMobileOpen = false;
-    }
   }
 
   ngAfterViewInit() {
+    const sidebar = document.querySelector('[sideBar]');
+    if (sidebar) {
+      if (this.usesDrawerSidebar()) sidebar.classList.add('close');
+      queueMicrotask(() => this.updateSidebarState(sidebar));
+    }
+
     const el = this.labelsScroll?.nativeElement;
     if (!el) return;
     this.updateLabelsOverflowState();


### PR DESCRIPTION
## Summary

- propagate the sidenav collapsed state to the main layout
- shrink the desktop sidebar layout slot from 280px to the 80px compact rail
- let the notes/content region reclaim the released 200px
- synchronize mobile-first initialization without triggering Angular lifecycle errors

## Motivation / Bug

Collapsing the upper-left menu reduced the visible navigation rail but its parent layout slot remained 280px wide, leaving an empty 200px gutter and preventing note cards from moving left.

## Test Evidence

- `npx -y -p node@24 -c 'node --version && npm run build'`
- browser interaction at an 811px desktop viewport: wrapper 280px → 80px; content left edge 280px → 80px; content width 514px → 714px
- expanded and collapsed screenshots captured from the built application
- independent final review of head `82de25e`: no remaining actionable findings

## Risks / Rollback

Low risk: the change only affects desktop widths of 600px and above. Mobile/native-phone layout continues to force the sidebar wrapper to zero width, and mobile-first collapsed state is carried into the 80px desktop rail after a breakpoint transition. Revert commit `82de25e` if needed.

## Follow-ups

- none